### PR TITLE
crash fix

### DIFF
--- a/lib/contentful/include_resolver.ex
+++ b/lib/contentful/include_resolver.ex
@@ -26,10 +26,15 @@ defmodule Contentful.IncludeResolver do
   end
 
   defp merge_includes(includes) do
-    all_includes = Enum.concat(
-      Map.get(includes, "Asset", []),
-      Map.get(includes, "Entry", [])
-    )
+    case includes do
+      nil ->
+        []
+      _ ->
+        Enum.concat(
+          Map.get(includes, "Asset", []),
+          Map.get(includes, "Entry", [])
+        )
+    end
   end
 
   defp resolve_include_field(field, includes) when is_list(field) do

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule Contentful.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     description: description,
-     package: package,
-     deps: deps,
+     description: description(),
+     package: package(),
+     deps: deps(),
      preferred_cli_env: [
        vcr: :test, "vcr.delete": :test, "vcr.check": :test, "vcr.show": :test
      ],

--- a/mix.lock
+++ b/mix.lock
@@ -7,8 +7,8 @@
   "httpoison": {:hex, :httpoison, "0.8.3", "b675a3fdc839a0b8d7a285c6b3747d6d596ae70b6ccb762233a990d7289ccae4", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []}}


### PR DESCRIPTION
if there are no includes at all, there is a crash, as it wasn't expecting this. So I just added a check. (I have an optional image asset link on a content type and when there are none this would occur). 

* crash fix - added check for includes being nil
* fixed some warnings for elixir 1.4 changes with brackets