### PR TITLE
Consider using atoms instead of strings?

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ACCESS_TOKEN = "my_access_token"
 entries = Contentful.Delivery.entries(SPACE_ID, ACCESS_TOKEN)
 
 # Printing Content Type ID for every entry
-Enum.each(entries, fn (entry) -> IO.puts(entry["sys"]["contentType"]["sys"]["id"]) end)
+Enum.each(entries, fn (entry) -> IO.puts(entry.sys.contentType.sys.id) end)
 ```
 
 * Single Entry:

--- a/lib/contentful/delivery.ex
+++ b/lib/contentful/delivery.ex
@@ -30,11 +30,11 @@ defmodule Contentful.Delivery do
 
     cond do
       params["resolve_includes"] == false ->
-        response["items"]
+        response[:items]
       true ->
         response
         |> Contentful.IncludeResolver.resolve_entry
-        |> Map.fetch!("items")
+        |> Map.fetch!(:items)
     end
   end
 
@@ -50,7 +50,7 @@ defmodule Contentful.Delivery do
       assets_url,
       access_token,
       params
-    )["items"]
+    ).items
   end
 
   def asset(space_id, access_token, asset_id, params \\ %{}) do
@@ -70,7 +70,7 @@ defmodule Contentful.Delivery do
       content_types_url,
       access_token,
       params
-    )["items"]
+    ).items
   end
 
   def content_type(space_id, access_token, content_type_id, params \\ %{}) do
@@ -116,6 +116,6 @@ defmodule Contentful.Delivery do
 
   defp process_response_body(body) do
     body
-    |> Poison.decode!
+    |> Poison.decode!([keys: :atoms])
   end
 end

--- a/lib/contentful/include_resolver.ex
+++ b/lib/contentful/include_resolver.ex
@@ -8,18 +8,18 @@ defmodule Contentful.IncludeResolver do
 
   def resolve_entry(entries) do
     cond do
-      Map.has_key?(entries, "items") ->
-        items = entries["items"]
+      Map.has_key?(entries, :items) ->
+        items = entries[:items]
         |> Enum.map(fn (entry) ->
-          resolve_include_field(entry, merge_includes(entries["includes"]))
+          resolve_include_field(entry, merge_includes(entries[:includes]))
         end)
-        Map.put(entries, "items", items)
+        Map.put(entries, :items, items)
 
-      Map.has_key?(entries, "item") ->
+      Map.has_key?(entries, :item) ->
         item =
-          entries["item"]
-          |> resolve_include_field(merge_includes(entries["includes"]))
-        Map.put(entries, "item", item)
+          entries[:item]
+          |> resolve_include_field(merge_includes(entries[:includes]))
+        Map.put(entries, :item, item)
 
       true -> entries
     end
@@ -31,8 +31,8 @@ defmodule Contentful.IncludeResolver do
         []
       _ ->
         Enum.concat(
-          Map.get(includes, "Asset", []),
-          Map.get(includes, "Entry", [])
+          Map.get(includes, :Asset, []),
+          Map.get(includes, :Entry, [])
         )
     end
   end
@@ -52,10 +52,10 @@ defmodule Contentful.IncludeResolver do
 
   defp replace_field(field, includes) do
     cond do
-      is_map(field) && field["sys"]["type"] == "Link" && (field["sys"]["linkType"] == "Asset" || field["sys"]["linkType"] == "Entry") ->
+      is_map(field) && field[:sys][:type] == "Link" && (field[:sys][:linkType] == "Asset" || field[:sys][:linkType] == "Entry") ->
         includes
         |> Enum.find(fn (match) ->
-          match["sys"]["id"] == field["sys"]["id"] end)
+          match.sys.id == field.sys.id end)
 
       true ->
         resolve_include_field(field, includes)

--- a/test/integration/contentful_test.exs
+++ b/test/integration/contentful_test.exs
@@ -36,7 +36,7 @@ defmodule Contentful.DeliveryTest do
     use_cassette "entry" do
       entry = Delivery.entry(@space_id, @access_token, "5JQ715oDQW68k8EiEuKOk8")
 
-      assert is_map(entry["fields"])
+      assert is_map(entry.fields)
     end
   end
 
@@ -45,7 +45,7 @@ defmodule Contentful.DeliveryTest do
       first_content_type = Delivery.content_types(@space_id, @access_token)
       |> List.first
 
-      assert is_list(first_content_type["fields"])
+      assert is_list(first_content_type.fields)
     end
   end
 
@@ -53,7 +53,7 @@ defmodule Contentful.DeliveryTest do
     use_cassette "content_type" do
       content_type = Delivery.content_type(@space_id, @access_token, "1kUEViTN4EmGiEaaeC6ouY")
 
-      assert is_list(content_type["fields"])
+      assert is_list(content_type.fields)
     end
   end
 
@@ -62,14 +62,14 @@ defmodule Contentful.DeliveryTest do
       first_asset = Delivery.assets(@space_id, @access_token)
       |> List.first
 
-      assert is_map(first_asset["fields"])
+      assert is_map(first_asset.fields)
     end
   end
 
   test "asset" do
     use_cassette "asset" do
       asset = Delivery.asset(@space_id, @access_token, "2ReMHJhXoAcy4AyamgsgwQ")
-      fields = asset["fields"]
+      fields = asset.fields
 
       assert is_map(fields)
     end
@@ -78,10 +78,10 @@ defmodule Contentful.DeliveryTest do
   test "space" do
     use_cassette "space" do
       space = Delivery.space(@space_id, @access_token)
-      locales = space["locales"]
+      locales = space.locales
       |> List.first
 
-      assert locales["code"] == "en-US"
+      assert locales.code == "en-US"
     end
   end
 end

--- a/test/integration/include_resolver_test.exs
+++ b/test/integration/include_resolver_test.exs
@@ -16,7 +16,6 @@ defmodule Contentful.IncludeResolverTest do
     use_cassette "entries" do
       entries =
         Delivery.entries(@space_id, @access_token, %{"resolve_includes" => true})
-
       assert is_list(entries)
     end
   end


### PR DESCRIPTION
First of all, thanks for the project!  How do you feel about using atoms over strings when decoding the HTTP responses?

Main objective for me is nicer access syntax, so instead of:

```elixir
entry["sys"]["contentType"]["sys"]["id"]
```

We can use

```elixir
entry.sys.contentType.sys.id
```

I know the argument of memory overload for atoms, but the key count should be constrained for it to not be an issue. 