### PR TITLE
Add configurable endpoint option

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,8 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :contentful, cf_endpoint:    System.get_env("CONTENTFUL_ENDPOINT")
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/lib/contentful/delivery.ex
+++ b/lib/contentful/delivery.ex
@@ -8,7 +8,7 @@ defmodule Contentful.Delivery do
   require Logger
   use HTTPoison.Base
 
-  @endpoint "cdn.contentful.com"
+  @endpoint Application.get_env(:contentful, :cf_endpoint)  
   @protocol "https"
 
   def space(space_id, access_token) do


### PR DESCRIPTION
Use CONTENTFUL_ENDPOINT variable to get the value of endpoint. This allows switch between preview.contentful.com and cdn.contentful.com