### PR TITLE
Handle Errors & Pagination

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,20 @@
+[
+  inputs: [
+    "{lib,config,test}/**/*.{ex,exs}",
+    "mix.exs"
+  ],
+  locals_without_parens: [
+    # Phoenix
+    action_fallback: 1,
+    plug: 2,
+    plug: 1,
+    pipe_through: 1,
+    get: 3,
+    post: 3,
+    patch: 3,
+    put: 3,
+    forward: 3,
+    resources: 2,
+    resources: 3
+  ]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+/.elixir_ls

--- a/fixture/vcr_cassettes/entries_401.json
+++ b/fixture/vcr_cassettes/entries_401.json
@@ -1,0 +1,44 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "Bearer bladjksflaksdjflkjkl",
+        "Accept": "application/json",
+        "User-Agent": "Contentful-Elixir"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://cdn.contentful.com/spaces/z3aswf9egfi8/entries"
+    },
+    "response": {
+      "body": "{\n  \"sys\": {\n    \"type\": \"Error\",\n    \"id\": \"AccessTokenInvalid\"\n  },\n  \"message\": \"The access token you sent could not be found or is invalid.\",\n  \"requestId\": \"503e974d4cb3f585ed34e988be2fa2d8\"\n}\n",
+      "headers": {
+        "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature",
+        "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Etag",
+        "Access-Control-Max-Age": "86400",
+        "Cache-Control": "max-age=0",
+        "Content-Type": "application/vnd.contentful.delivery.v1+json",
+        "Server": "Contentful",
+        "X-Content-Type-Options": "nosniff",
+        "X-Contentful-Request-Id": "503e974d4cb3f585ed34e988be2fa2d8",
+        "Content-Length": "198",
+        "Accept-Ranges": "bytes",
+        "Date": "Mon, 26 Mar 2018 21:08:05 GMT",
+        "Via": "1.1 varnish",
+        "Age": "0",
+        "Connection": "keep-alive",
+        "X-Served-By": "cache-sea1044-SEA",
+        "X-Cache": "MISS",
+        "X-Cache-Hits": "0",
+        "X-Timer": "S1522098485.046122,VS0,VE137",
+        "Vary": "Accept-Encoding"
+      },
+      "status_code": 401,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/entries_404.json
+++ b/fixture/vcr_cassettes/entries_404.json
@@ -1,0 +1,43 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "Bearer ACCESS_TOKEN",
+        "Accept": "application/json",
+        "User-Agent": "Contentful-Elixir"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://cdn.contentful.com/spaces//entries"
+    },
+    "response": {
+      "body": "{\n  \"sys\": {\n    \"type\": \"Error\",\n    \"id\": \"NotFound\"\n  },\n  \"message\": \"The resource could not be found.\",\n  \"requestId\": \"10fb831cf47afd1c3f3cb4fb32fd69ca\"\n}\n",
+      "headers": {
+        "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature",
+        "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Etag",
+        "Access-Control-Max-Age": "86400",
+        "Cache-Control": "max-age=0",
+        "Content-Type": "application/octet-stream",
+        "Server": "Contentful",
+        "X-Content-Type-Options": "nosniff",
+        "X-Contentful-Request-Id": "10fb831cf47afd1c3f3cb4fb32fd69ca",
+        "Content-Length": "161",
+        "Accept-Ranges": "bytes",
+        "Date": "Mon, 26 Mar 2018 21:11:14 GMT",
+        "Via": "1.1 varnish",
+        "Age": "0",
+        "Connection": "keep-alive",
+        "X-Served-By": "cache-sea1047-SEA",
+        "X-Cache": "MISS",
+        "X-Cache-Hits": "0",
+        "X-Timer": "S1522098675.892229,VS0,VE67"
+      },
+      "status_code": 404,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/contentful/delivery.ex
+++ b/lib/contentful/delivery.ex
@@ -119,7 +119,7 @@ defmodule Contentful.Delivery do
       query =
         params
         |> Enum.reduce("", fn {k, v}, acc -> acc <> "#{k}=#{v}&" end)
-        |> String.rstrip(?&)
+        |> String.trim_trailing()
 
       "#{path}/?#{query}"
     else

--- a/lib/contentful/delivery.ex
+++ b/lib/contentful/delivery.ex
@@ -23,17 +23,16 @@ defmodule Contentful.Delivery do
   def entries(space_id, access_token, params \\ %{}) do
     entries_url = "/spaces/#{space_id}/entries"
 
-    response = contentful_request(
-      entries_url,
-      access_token,
-      Map.delete(params, "resolve_includes"))
+    response =
+      contentful_request(entries_url, access_token, Map.delete(params, "resolve_includes"))
 
     cond do
       params["resolve_includes"] == false ->
         response["items"]
+
       true ->
         response
-        |> Contentful.IncludeResolver.resolve_entry
+        |> Contentful.IncludeResolver.resolve_entry()
         |> Map.fetch!("items")
     end
   end
@@ -86,7 +85,7 @@ defmodule Contentful.Delivery do
   defp contentful_request(uri, access_token, params \\ %{}) do
     final_url = format_path(path: uri, params: params)
 
-    Logger.debug "GET #{final_url}"
+    Logger.debug("GET #{final_url}")
 
     get!(final_url, client_headers(access_token)).body
   end
@@ -101,9 +100,11 @@ defmodule Contentful.Delivery do
 
   defp format_path(path: path, params: params) do
     if Enum.any?(params) do
-      query = params
-      |> Enum.reduce("", fn ({k, v}, acc) -> acc <> "#{k}=#{v}&" end)
-      |> String.rstrip(?&)
+      query =
+        params
+        |> Enum.reduce("", fn {k, v}, acc -> acc <> "#{k}=#{v}&" end)
+        |> String.rstrip(?&)
+
       "#{path}/?#{query}"
     else
       path
@@ -116,6 +117,6 @@ defmodule Contentful.Delivery do
 
   defp process_response_body(body) do
     body
-    |> Poison.decode!
+    |> Poison.decode!()
   end
 end

--- a/lib/contentful/include_resolver.ex
+++ b/lib/contentful/include_resolver.ex
@@ -9,19 +9,23 @@ defmodule Contentful.IncludeResolver do
   def resolve_entry(entries) do
     cond do
       Map.has_key?(entries, "items") ->
-        items = entries["items"]
-        |> Enum.map(fn (entry) ->
-          resolve_include_field(entry, merge_includes(entries["includes"]))
-        end)
+        items =
+          entries["items"]
+          |> Enum.map(fn entry ->
+            resolve_include_field(entry, merge_includes(entries["includes"]))
+          end)
+
         Map.put(entries, "items", items)
 
       Map.has_key?(entries, "item") ->
         item =
           entries["item"]
           |> resolve_include_field(merge_includes(entries["includes"]))
+
         Map.put(entries, "item", item)
 
-      true -> entries
+      true ->
+        entries
     end
   end
 
@@ -29,6 +33,7 @@ defmodule Contentful.IncludeResolver do
     case includes do
       nil ->
         []
+
       _ ->
         Enum.concat(
           Map.get(includes, "Asset", []),
@@ -38,28 +43,31 @@ defmodule Contentful.IncludeResolver do
   end
 
   defp resolve_include_field(field, includes) when is_list(field) do
-    Enum.map(field, fn (field) ->
+    Enum.map(field, fn field ->
       resolve_include_field(replace_field(field, includes), includes)
     end)
   end
+
   defp resolve_include_field(field, includes) when is_map(field) do
-    Enum.map(Map.keys(field), fn (key) ->
+    Enum.map(Map.keys(field), fn key ->
       {key, replace_field(field[key], includes)}
     end)
     |> Enum.into(%{})
   end
+
   defp resolve_include_field(field, _includes), do: field
 
   defp replace_field(field, includes) do
     cond do
-      is_map(field) && field["sys"]["type"] == "Link" && (field["sys"]["linkType"] == "Asset" || field["sys"]["linkType"] == "Entry") ->
+      is_map(field) && field["sys"]["type"] == "Link" &&
+          (field["sys"]["linkType"] == "Asset" || field["sys"]["linkType"] == "Entry") ->
         includes
-        |> Enum.find(fn (match) ->
-          match["sys"]["id"] == field["sys"]["id"] end)
+        |> Enum.find(fn match ->
+          match["sys"]["id"] == field["sys"]["id"]
+        end)
 
       true ->
         resolve_include_field(field, includes)
     end
   end
-
 end

--- a/lib/contentful/include_resolver.ex
+++ b/lib/contentful/include_resolver.ex
@@ -2,8 +2,8 @@ defmodule Contentful.IncludeResolver do
   @moduledoc """
   This module contains functions to resolve the includes.
   Later, this module will also have the responsability to make new
-  contentful API request to satisfy the missing link to satisfy
-  the current missing links if they are not part of the includes.
+  contentful API request to satisfy the current missing links if they
+  are not part of the includes.
   """
 
   def resolve_entry(entries) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,17 +2,21 @@ defmodule Contentful.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :contentful,
-     version: "0.1.1",
-     elixir: "~> 1.2",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps(),
-     preferred_cli_env: [
-       vcr: :test, "vcr.delete": :test, "vcr.check": :test, "vcr.show": :test
-     ],
+    [
+      app: :contentful,
+      version: "0.1.1",
+      elixir: "~> 1.2",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      preferred_cli_env: [
+        vcr: :test,
+        "vcr.delete": :test,
+        "vcr.check": :test,
+        "vcr.show": :test
+      ]
     ]
   end
 
@@ -20,10 +24,12 @@ defmodule Contentful.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [
-      :logger,
-      :httpoison
-    ]]
+    [
+      applications: [
+        :logger,
+        :httpoison
+      ]
+    ]
   end
 
   # Dependencies can be Hex packages:
@@ -51,14 +57,15 @@ defmodule Contentful.Mixfile do
   end
 
   defp package do
-    [# These are the default files included in the package
-     name: :contentful,
-     files: ["lib", "mix.exs", "README*", "LICENSE*"],
-     maintainers: ["Contentful GmbH (David Litvak Bruno)"],
-     licenses: ["MIT"],
-     links: %{
-       "GitHub" => "https://github.com/contentful-labs/contentful.ex"
-     }
+    # These are the default files included in the package
+    [
+      name: :contentful,
+      files: ["lib", "mix.exs", "README*", "LICENSE*"],
+      maintainers: ["Contentful GmbH (David Litvak Bruno)"],
+      licenses: ["MIT"],
+      links: %{
+        "GitHub" => "https://github.com/contentful-labs/contentful.ex"
+      }
     ]
   end
 end

--- a/test/integration/contentful_test.exs
+++ b/test/integration/contentful_test.exs
@@ -3,11 +3,11 @@ defmodule Contentful.DeliveryTest do
   alias Contentful.Delivery
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
-  @access_token  "ACCESS_TOKEN"
-  @space_id      "z3aswf9egfi8"
+  @access_token "ACCESS_TOKEN"
+  @space_id "z3aswf9egfi8"
 
   setup_all do
-    HTTPoison.start
+    HTTPoison.start()
   end
 
   @tag timeout: 10000
@@ -22,11 +22,14 @@ defmodule Contentful.DeliveryTest do
   test "search entry with includes" do
     use_cassette "single_entry_with_includes" do
       space_id = "if4k9hkjacuz"
-      entries = Delivery.entries(space_id, @access_token, %{
-            "content_type" => "6pFEhaSgDKimyOCE0AKuqe",
-            "fields.slug" => "test-page",
-            "include" => "10"}
-      )
+
+      entries =
+        Delivery.entries(space_id, @access_token, %{
+          "content_type" => "6pFEhaSgDKimyOCE0AKuqe",
+          "fields.slug" => "test-page",
+          "include" => "10"
+        })
+
       assert is_list(entries)
     end
   end
@@ -42,8 +45,9 @@ defmodule Contentful.DeliveryTest do
 
   test "content_types" do
     use_cassette "content_types" do
-      first_content_type = Delivery.content_types(@space_id, @access_token)
-      |> List.first
+      first_content_type =
+        Delivery.content_types(@space_id, @access_token)
+        |> List.first()
 
       assert is_list(first_content_type["fields"])
     end
@@ -59,8 +63,9 @@ defmodule Contentful.DeliveryTest do
 
   test "assets" do
     use_cassette "assets" do
-      first_asset = Delivery.assets(@space_id, @access_token)
-      |> List.first
+      first_asset =
+        Delivery.assets(@space_id, @access_token)
+        |> List.first()
 
       assert is_map(first_asset["fields"])
     end
@@ -78,8 +83,10 @@ defmodule Contentful.DeliveryTest do
   test "space" do
     use_cassette "space" do
       space = Delivery.space(@space_id, @access_token)
-      locales = space["locales"]
-      |> List.first
+
+      locales =
+        space["locales"]
+        |> List.first()
 
       assert locales["code"] == "en-US"
     end

--- a/test/integration/contentful_test.exs
+++ b/test/integration/contentful_test.exs
@@ -10,11 +10,32 @@ defmodule Contentful.DeliveryTest do
     HTTPoison.start()
   end
 
-  @tag timeout: 10000
-  test "entries" do
-    use_cassette "entries" do
-      entries = Delivery.entries(@space_id, @access_token)
-      assert is_list(entries)
+  describe ".entries" do
+    @tag timeout: 10000
+    test "fetches entries successfully with valid space_id & access_token" do
+      use_cassette "entries" do
+        assert {:ok,
+                %{
+                  "items" => items,
+                  "limit" => 100,
+                  "skip" => 0,
+                  "total" => 6
+                }} = Delivery.entries(@space_id, @access_token)
+
+        assert is_list(items)
+      end
+    end
+
+    test "handles unauthorized error from invalid access_token" do
+      use_cassette "entries_401" do
+        assert {:error, :not_authorized} == Delivery.entries(@space_id, "bladjksflaksdjflkjkl")
+      end
+    end
+
+    test "handles not found error from invalid space_id" do
+      use_cassette "entries_404" do
+        assert {:error, :not_found} == Delivery.entries("", @access_token)
+      end
     end
   end
 
@@ -23,7 +44,7 @@ defmodule Contentful.DeliveryTest do
     use_cassette "single_entry_with_includes" do
       space_id = "if4k9hkjacuz"
 
-      entries =
+      {:ok, %{"items" => entries}} =
         Delivery.entries(space_id, @access_token, %{
           "content_type" => "6pFEhaSgDKimyOCE0AKuqe",
           "fields.slug" => "test-page",
@@ -45,9 +66,8 @@ defmodule Contentful.DeliveryTest do
 
   test "content_types" do
     use_cassette "content_types" do
-      first_content_type =
+      {:ok, %{"items" => [first_content_type | _]}} =
         Delivery.content_types(@space_id, @access_token)
-        |> List.first()
 
       assert is_list(first_content_type["fields"])
     end
@@ -55,7 +75,8 @@ defmodule Contentful.DeliveryTest do
 
   test "content_type" do
     use_cassette "content_type" do
-      content_type = Delivery.content_type(@space_id, @access_token, "1kUEViTN4EmGiEaaeC6ouY")
+      {:ok, content_type} =
+        Delivery.content_type(@space_id, @access_token, "1kUEViTN4EmGiEaaeC6ouY")
 
       assert is_list(content_type["fields"])
     end
@@ -63,9 +84,7 @@ defmodule Contentful.DeliveryTest do
 
   test "assets" do
     use_cassette "assets" do
-      first_asset =
-        Delivery.assets(@space_id, @access_token)
-        |> List.first()
+      {:ok, %{"items" => [first_asset | _]}} = Delivery.assets(@space_id, @access_token)
 
       assert is_map(first_asset["fields"])
     end
@@ -73,7 +92,7 @@ defmodule Contentful.DeliveryTest do
 
   test "asset" do
     use_cassette "asset" do
-      asset = Delivery.asset(@space_id, @access_token, "2ReMHJhXoAcy4AyamgsgwQ")
+      {:ok, asset} = Delivery.asset(@space_id, @access_token, "2ReMHJhXoAcy4AyamgsgwQ")
       fields = asset["fields"]
 
       assert is_map(fields)
@@ -82,7 +101,7 @@ defmodule Contentful.DeliveryTest do
 
   test "space" do
     use_cassette "space" do
-      space = Delivery.space(@space_id, @access_token)
+      {:ok, space} = Delivery.space(@space_id, @access_token)
 
       locales =
         space["locales"]

--- a/test/integration/include_resolver_test.exs
+++ b/test/integration/include_resolver_test.exs
@@ -4,18 +4,17 @@ defmodule Contentful.IncludeResolverTest do
   alias Contentful.IncludeResolver
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
-  @access_token  "ACCESS_TOKEN"
-  @space_id      "z3aswf9egfi8"
+  @access_token "ACCESS_TOKEN"
+  @space_id "z3aswf9egfi8"
 
   setup_all do
-    HTTPoison.start
+    HTTPoison.start()
   end
 
   @tag timeout: 10000
   test "entries" do
     use_cassette "entries" do
-      entries =
-        Delivery.entries(@space_id, @access_token, %{"resolve_includes" => true})
+      entries = Delivery.entries(@space_id, @access_token, %{"resolve_includes" => true})
 
       assert is_list(entries)
     end
@@ -25,24 +24,26 @@ defmodule Contentful.IncludeResolverTest do
   test "search entry with includes" do
     use_cassette "single_entry_with_includes" do
       space_id = "if4k9hkjacuz"
-      entries = Delivery.entries(space_id, @access_token, %{
-            "content_type" => "6pFEhaSgDKimyOCE0AKuqe",
-            "fields.slug" => "test-page",
-            "include" => "10",
-            "resolve_includes" => true})
+
+      entries =
+        Delivery.entries(space_id, @access_token, %{
+          "content_type" => "6pFEhaSgDKimyOCE0AKuqe",
+          "fields.slug" => "test-page",
+          "include" => "10",
+          "resolve_includes" => true
+        })
 
       assert is_list(entries)
     end
   end
 
-
   @tag timeout: 10000
   test "entry" do
     use_cassette "entry" do
-      entry = Delivery.entry(@space_id,
-        @access_token,
-        "5JQ715oDQW68k8EiEuKOk8",
-        %{"resolve_includes" => true})
+      entry =
+        Delivery.entry(@space_id, @access_token, "5JQ715oDQW68k8EiEuKOk8", %{
+          "resolve_includes" => true
+        })
 
       assert is_map(entry)
     end


### PR DESCRIPTION
Closes #15. 

This PR does the following 

1. Updates the delivery module to the standard `{:ok, response}` `{:error, response}` convention, rather than throwing exceptions using `get!`
2. Returns entire response, not just `response["items"]`, so the keys like `total`, `limit`, & `skip` are also returned for pagination purposes. 
3. Add better error handling around 404s & 401s. 
4. Update tests to reflect changes.