### PR TITLE
Adds latest OTP and Elixir for test runs

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,8 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        otp: [22.3, 21.3]
-        elixir: [1.10.4, 1.9.4, 1.8.2, 1.7.4]
+        otp: [23.1, 22.3, 21.3]
+        elixir: [1.11, 1.10.4, 1.9.4, 1.8.2, 1.7.4]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Small PR to add the recently released Elixir 1.11 and OTP 23.1 into the list of dependencies.

