### PR TITLE
Add config for native GH-Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates
+version: 2
+
+updates:
+
+- package-ecosystem: mix
+  directory: "/"
+  schedule:
+    interval: daily # default: 05:00 UTC
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily # default: 05:00 UTC


### PR DESCRIPTION
I suggested that in the review of #86.
Also closes #82.

-----

TODOs:
- [x] needs rebasing once #86 is merged, so CI builds don't fail anymore.